### PR TITLE
Treat comma and dot as separator

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,7 +4,7 @@ import { explicit, or, regexp, topOfLine } from './combinator'
 
 const parseBold = explicit(
   regexp(
-    /^\*(\S([^*\n]*?|[^*\n]*? `.*?` )\S|\S)\*(?=\s|$)/,
+    /^\*(\S([^*\n]*?|[^*\n]*? `.*?` )\S|\S)\*(?=[\s.,]|$)/,
     (match, text, position, parseText) => {
       const [matchedText, content] = match
 
@@ -49,7 +49,7 @@ const parsePreText = explicit(
 
 const parseItalic = explicit(
   regexp(
-    /^_(\S([^_\n]*?|[^_\n]*? `.*?` )\S|\S)\_(?=\s|$)/,
+    /^_(\S([^_\n]*?|[^_\n]*? `.*?` )\S|\S)\_(?=[\s.,]|$)/,
     (match, text, position, parseText) => {
       const [matchedText, content] = match
 
@@ -66,7 +66,7 @@ const parseItalic = explicit(
 
 const parseStrike = explicit(
   regexp(
-    /^~(\S([^~\n]*?|[^~\n]*? `.*?` )\S|\S)\~(?=\s|$)/,
+    /^~(\S([^~\n]*?|[^~\n]*? `.*?` )\S|\S)\~(?=[\s.,]|$)/,
     (match, text, position, parseText) => {
       const [matchedText, content] = match
 

--- a/tests/issues.spec.ts
+++ b/tests/issues.spec.ts
@@ -1,0 +1,32 @@
+import { parse } from '../src'
+
+import { bold, code, italic, root, strike, text } from './helpers'
+
+describe('#4', () => {
+  it('Should parse correctly', () => {
+    const test =
+      'This is _the_ *first* ~program~ `code of the rest of this` *file*, err, _file_, and by ~file~, I mean *file*.'
+
+    const expected = root([
+      text('This is '),
+      italic([text('the')]),
+      text(' '),
+      bold([text('first')]),
+      text(' '),
+      strike([text('program')]),
+      text(' '),
+      code('code of the rest of this'),
+      text(' '),
+      bold([text('file')]),
+      text(', err, '),
+      italic([text('file')]),
+      text(', and by '),
+      strike([text('file')]),
+      text(', I mean '),
+      bold([text('file')]),
+      text('.')
+    ])
+
+    expect(parse(test)).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Fix #4 

* For `*bold*`, `_italic_` and `~strike~`, comma and dot(period) acts like as spaces.