### PR TITLE
Limit variations only to skin-tone

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -120,7 +120,7 @@ const parseMultilineQuote = topOfLine(
 )
 
 const parseEmoji = regexp(
-  /^:([^:<]+?)(::([^:]+?))?:/,
+  /^:([^:<]+?):(:(skin-tone-.+?):)?/,
   (match, text, position) => {
     const [matchedText, name, _, variation] = match
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -151,8 +151,24 @@ describe('Emoji parser', () => {
     )
   })
 
-  it('Should parse emoji with variation', () => {
-    expect(parse(':foo::bar:')).toEqual(root([emoji('foo', 'bar')]))
+  it('Should parse emoji with skin-tone variation', () => {
+    expect(parse(':foo::skin-tone-1:')).toEqual(
+      root([emoji('foo', 'skin-tone-1')])
+    )
+  })
+
+  it('Should parse sequential emojis', () => {
+    expect(parse('ab:cd::ef::skin-tone-1:g:h::i:jk')).toEqual(
+      root([
+        text('ab'),
+        emoji('cd'),
+        emoji('ef', 'skin-tone-1'),
+        text('g'),
+        emoji('h'),
+        emoji('i'),
+        text('jk')
+      ])
+    )
   })
 
   it('Should parse "foo:bar:baz" as emoji', () => {

--- a/tests/issues.spec.ts
+++ b/tests/issues.spec.ts
@@ -1,6 +1,6 @@
 import { parse } from '../src'
 
-import { bold, code, italic, root, strike, text } from './helpers'
+import { bold, code, emoji, italic, root, strike, text } from './helpers'
 
 describe('#4', () => {
   it('Should parse correctly', () => {
@@ -28,5 +28,11 @@ describe('#4', () => {
     ])
 
     expect(parse(test)).toEqual(expected)
+  })
+})
+
+describe('#6', () => {
+  it('Treat only "skin-tone-*" as variations', () => {
+    expect(parse(':a::b:')).toEqual(root([emoji('a'), emoji('b')]))
   })
 })


### PR DESCRIPTION
Fix #6 

To parse an emoji sequence correctly, treat only `:foo::skin-tone-bar:` as emoji with variations.