### PR TITLE
fix emoji regex to not match other markup

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -123,7 +123,7 @@ const parseMultilineQuote = topOfLine(
 )
 
 const parseEmoji = regexp(
-  /^:([^:<`*#@!]+):(:(skin-tone-.+?):)?/,
+  /^:([^:<`*#@!\s]+):(:(skin-tone-.+?):)?/,
   (match, text, position) => {
     const [matchedText, name, _, variation] = match
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -123,7 +123,7 @@ const parseMultilineQuote = topOfLine(
 )
 
 const parseEmoji = regexp(
-  /^:([^:<]+?):(:(skin-tone-.+?):)?/,
+  /^:([^:<`*#@!]+):(:(skin-tone-.+?):)?/,
   (match, text, position) => {
     const [matchedText, name, _, variation] = match
 


### PR DESCRIPTION
Fixes cases such as:

this is fail: `this is not an emoji:`

