### PR TITLE
specify parse output as Root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Node, NodeType } from './types/Node'
+import { Node, Root, NodeType } from './types/Node'
 import { ParseText } from './types/Parser'
 
 import parser from './parser'
@@ -44,7 +44,7 @@ const parseText: ParseText = text => {
   return children
 }
 
-export const parse = (message: string): Node => {
+export const parse = (message: string): Root => {
   return {
     type: NodeType.Root,
     children: parseText(message)


### PR DESCRIPTION
Trivial but nice change to make Typescript usage easier.

Can let users turn 

```
const baseNode = parse(text) as Root;
const nodes = baseNode.children
```

to 

```
const nodes = parse(text).children
```