### PR TITLE
Parse bold formatting properly with various punctuation suffixes

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,7 +4,7 @@ import { explicit, or, regexp, topOfLine } from './combinator'
 
 const parseBold = explicit(
   regexp(
-    /^\*(\S([^*\n]*?|[^*\n]*? `.*?` )\S|\S)\*(?=[\s.,\])}!?\-=]|$)/,
+    /^\*(\S([^*\n]*?|[^*\n]*? `.*?` )[^\s*]|\S)\*(?=[\s~!#$%^)\-+={}[\];:'",.?/]|$)/,
     (match, text, position, parseText) => {
       const [matchedText, content] = match
 

--- a/tests/issues.spec.ts
+++ b/tests/issues.spec.ts
@@ -59,3 +59,62 @@ describe('#22', () => {
     )
   })
 })
+
+// https://github.com/pocka/slack-message-parser/issues/34
+describe('#34', () => {
+  it('parses bold formatting properly with various punctuation suffixes', () => {
+    expect(
+      parse(
+        '*Y*~ *N*` *Y*! *N*@ *Y*# *Y*$ *Y*% *Y*^ *N*& *N** *N*( *Y*) *N*_ *Y*- *Y*+ *Y*= *Y*{ *Y*} *Y*[ *Y*] *N*| *N*\\ *Y*; *Y*: *Y*\' *Y*" *N*< *Y*, *N*> *Y*. *Y*? *Y*/ *Y*'
+      )
+    ).toEqual(
+      root([
+        bold([text('Y')]),
+        text('~ *N*` '),
+        bold([text('Y')]),
+        text('! *N*@ '),
+        bold([text('Y')]),
+        text('# '),
+        bold([text('Y')]),
+        text('$ '),
+        bold([text('Y')]),
+        text('% '),
+        bold([text('Y')]),
+        text('^ *N*& *N** *N*( '),
+        bold([text('Y')]),
+        text(') *N*_ '),
+        bold([text('Y')]),
+        text('- '),
+        bold([text('Y')]),
+        text('+ '),
+        bold([text('Y')]),
+        text('= '),
+        bold([text('Y')]),
+        text('{ '),
+        bold([text('Y')]),
+        text('} '),
+        bold([text('Y')]),
+        text('[ '),
+        bold([text('Y')]),
+        text('] *N*| *N*\\ '),
+        bold([text('Y')]),
+        text('; '),
+        bold([text('Y')]),
+        text(': '),
+        bold([text('Y')]),
+        text("' "),
+        bold([text('Y')]),
+        text('" *N*< '),
+        bold([text('Y')]),
+        text(', *N*> '),
+        bold([text('Y')]),
+        text('. '),
+        bold([text('Y')]),
+        text('? '),
+        bold([text('Y')]),
+        text('/ '),
+        bold([text('Y')])
+      ])
+    )
+  })
+})


### PR DESCRIPTION
Fixes #34.

- Replaces the final `\S` with `[^s*]` to prevent treating a `*...**` as a proper bold format
- Adds to the lookahead all the additional ASCII punctuation marks I could find that Slack considers valid suffixes for bold formats
- Added a test to `issues.spec.ts` to capture these cases